### PR TITLE
Ver 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@
 	演讲切割小音频 https://pan.baidu.com/s/1jIrC0F8#list/path=%2F
 ## 联系方式 ##
   wj3235@126.com
-
+  
+  
+## 更新日志 ##  
+Ver 0.0.1
+  * 中值滤波scipy.signal.medfilt计算速度较慢,更新计算方法
+  * get_wave_statistic函数添加framerate(采样率)参数,支持8000/16000,添加处理(无声音时长超过17s切为多个16.999s的无声音时长)
+  * calculate_other_statistic_info函数添加framerate(采样率)参数,支持8000/16000
+  * 修改原来循环排序生成间隔小于17s时间点数组算法(每次循环采用折半插入排序,因为插入的是排好序的数组,原来每次循环采用sort,视频时长超过1小时的话基本算不完了...)
+  * 去掉原来将wav切成具体的小文件步骤,直接使用流访问百度api
+  * 修改保存字幕格式可以直接使用ffmpeg将字幕烧制到视频中
+  * 修改speech_recognizai_baidu方法接受流,不再去读文件
+  * 添加注释 
+  * 添加ffmpeg分离音频,烧制字幕指令
 ©2017 alex All Rights Reserved.
   
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Ver 0.0.1
   * 修改speech_recognizai_baidu方法接受流,不再去读文件
   * 添加注释 
   * 添加ffmpeg分离音频,烧制字幕指令
+  
 ©2017 alex All Rights Reserved.
   
 

--- a/src/audiostatistic.py
+++ b/src/audiostatistic.py
@@ -5,7 +5,7 @@ Created on Sun Aug 06 05:26:49 2017
 @contact wj3235@126.com
 """
 
-def get_wave_statistic(waveData,threshhold=0.2):
+def get_wave_statistic(waveData,framerate,threshhold=0.2):
     splitlist=[]
     
     zerolen=0
@@ -17,6 +17,9 @@ def get_wave_statistic(waveData,threshhold=0.2):
         pre=0  
    
     for v in waveData:    
+        #如果当前点和上一个点都大于0.2或者都小于0.2
+        #都小于的话空长度加1,zerolen
+        #都大于的话有生长度加1,nonezerolen
         if (abs(v)<=threshhold and abs(pre) <= threshhold) or (abs(v)>threshhold and abs(pre) >threshhold) :
             if abs(v)<=threshhold:
                 zerolen+=1
@@ -24,13 +27,21 @@ def get_wave_statistic(waveData,threshhold=0.2):
             else:
                 nonezerolen+=1
                 zerolen=0
-            
+        #有声音无声音状态转换   
         elif (abs(v)<=threshhold and abs(pre) > threshhold) or (abs(v)>threshhold and abs(pre) <= threshhold):
+            #由无声转入有声状态
+            #无声长度+1,记录无声长度,False
             if abs(v)>threshhold:
                 if len(splitlist)!=0:
                     zerolen+=1
                     nonezerolen=0
+                if zerolen>framerate*17-1:
+                    while zerolen>framerate*17-1:
+                        splitlist.append([False,framerate*17-1,0,0,0])
+                        zerolen-=framerate*17-1
                 splitlist.append([False,zerolen,0,0,0])
+            #由有声转入无声状态
+            #有声长度+1,记录无声长度,True
             else:
                 if len(splitlist)!=0:                
                     nonezerolen+=1
@@ -38,8 +49,9 @@ def get_wave_statistic(waveData,threshhold=0.2):
                 splitlist.append([True,nonezerolen,0,0,0])
         pre=v
     
-    print 'zerolen',zerolen,'nonezerolen',nonezerolen
+    #print 'zerolen',zerolen,'nonezerolen',nonezerolen
     
+    #循环完之后,添加最后一段有/无声段
     if zerolen:
         splitlist.append([False,zerolen,0,0,0])
     if nonezerolen:
@@ -49,16 +61,19 @@ def get_wave_statistic(waveData,threshhold=0.2):
 #statistic collum : flase/true continueframenum id accumulatetime middletimestamp
 #assign id
 #get accumulatetime,middletimestamp
-def calculate_other_statistic_info(wavestatistic):
+def calculate_other_statistic_info(wavestatistic,framerate):
     id=1
     sum=0    
     for record in wavestatistic:
-        t=(sum+record[1]/2.0)*1/8000
+        t=(sum+record[1]/2.0)*1/framerate#8000应为频率值,算出到目前时长总长,单位为s
         sum+=record[1]
-        record[2]=id
-        record[3]=sum   
+        record[2]=id #序列
+        record[3]=sum #字节长度累积,等于时长累计*8000*(双字节Int16)
         record[4]=t  
         id+=1
-        txt='%s %s %s %s %s\n'%(record[2],record[0],record[1],record[3],record[4])
-        #print txt
+        #txt='%s %s %s %s %s\n'%(record[2],record[0],record[1],record[3],record[4])
+        if(record[1]>2*17*framerate):
+            #print (record[1])
+            break;
+    #print (wavestatistic[:10])
         

--- a/src/autosubtitle.py
+++ b/src/autosubtitle.py
@@ -7,6 +7,10 @@ Created on Sun Aug 06 05:26:49 2017
 
 import os
 import shutil
+import sys
+import time
+
+#NumPy系统是Python的一种开源的数值计算扩展。这种工具可用来存储和处理大型矩阵
 
 import numpy as np
 from scipy import signal
@@ -28,17 +32,38 @@ def plot_data(waveData,nframes,framerate):
     plt.title("Single channel wavedata")
     plt.grid('on')#标尺，on：有，off:无。
     fig.savefig('test2png.png', dpi=100)
-    print len(waveData)
-    print (waveData[0:1000])
+    #print len(waveData)
+    #print (waveData[0:1000])
 
 def timevalidate(timetable,endtime,timerange):
-    timetable+=[endtime]
-    ordertime=sorted(timetable)
-    for i in range(len(ordertime)-1):
-        if ordertime[i+1]-ordertime[i]>timerange:
-            print ordertime[i+1],ordertime[i]
+    timetable+=[endtime]    
+    for i in range(len(timetable)-1):
+        if timetable[i+1]-timetable[i]>timerange:
             return False            
     return True    
+
+#折半插入排序
+def insertsort(timearr,item):
+    if len(timearr)==1:
+        timearr.append(item) if item>timearr[0] else timearr.insert(0,item)
+    elif len(timearr)==2:
+        if item>timearr[0]:
+            timearr.append(item) if item>timearr[1] else timearr.insert(1,item)
+        else:
+            timearr.insert(0,item)
+    else:
+        if item<timearr[0]:
+            timearr.insert(0,item)
+        elif item>timearr[len(timearr)-1]:
+            timearr.append(item)
+        else:
+            middle(timearr,0,len(timearr)-1,item)
+#折半插入排序递归方法        
+def middle(timearr,start,end,item):
+    if end-start==1:        
+        timearr.insert(end,item)
+    else:        
+        middle(timearr,start,(start+end)//2,item) if timearr[(start+end)//2]>item else middle(timearr,(start+end)//2,end,item)        
 
 def time_transform(seconds):
     m, s = divmod(seconds, 60)
@@ -50,35 +75,61 @@ if __name__ =="__main__":
     laguage='zh'
     laguage='en'
     nchannels, sampwidth, framerate, nframes,strData=load_wave(wavepath)
-    waveData = np.fromstring(strData,dtype=np.int16)   
     
-    waveData=signal.medfilt(waveData)    
-    waveData = waveData*1.0/(max(abs(waveData)))#wave幅值归一化
+    # 使用字符串创建矩阵,简单的转换实现了ASCII码的转换,int16使得每2个字符(16位)转化成10进制的数组
+    waveData = np.fromstring(strData,dtype=np.int16)       
+        
+    #中值滤波medfilt计算太慢,使用下面方法速度提升一倍
+    #waveData=signal.medfilt(waveData)
+    middata=[0]*len(waveData)
+    if(len(waveData)>2):
+        middata[0]=sorted([0,waveData[1],waveData[2]])[1]
+        middata[len(waveData)-1]=sorted([0,waveData[len(waveData)-1],waveData[len(waveData)-2]])[1]
+    for i in range(1,len(waveData)-1):
+        
+        middata[i]=(waveData[i] if waveData[i] > waveData[i+1] else\
+        (waveData[i+1] if waveData[i-1] > waveData[i+1] else waveData[i-1]))\
+        if waveData[i-1] > waveData[i] else\
+        (waveData[i-1] if waveData[i-1] > waveData[i+1] else\
+        (waveData[i+1] if waveData[i] > waveData[i+1] else waveData[i]));
+    for j in range(len(waveData)):
+        waveData[j]=middata[j]
+        
+    #wave幅值归一化 取数组中最大的值为分母,每个元素作为分母
+    waveData = waveData*1.0/(max(abs(waveData)))
     if nchannels>1:
         waveData = np.reshape(waveData,[nframes,nchannels])
         waveData=waveData[:,0]
 
-    #plot_data(waveData,nframes,framerate)
-    wavestatistic=get_wave_statistic(waveData)
-    print 'len(wavestatistic)',(len(wavestatistic))
+    #plot_data(waveData,nframes,framerate)#绘制音频波谱图片
+    #统计有声音和没声音的分段每段时长
+    wavestatistic=get_wave_statistic(waveData,framerate)
+    #print 'len(wavestatistic)',(len(wavestatistic))
     
-    calculate_other_statistic_info(wavestatistic)
+    calculate_other_statistic_info(wavestatistic,framerate)
     
     sortedwavestatistic=sorted(wavestatistic,key=lambda x:(x[0],-x[1]))
 
     splittimestamp=[0]
     for split in sortedwavestatistic:
-        splittimestamp+=[split[4]]
-        if timevalidate(splittimestamp,nframes*1.0/8000,17):
+        #splittimestamp+=[split[4]]
+        
+        #split[4]为音频时间点,表示到目前时长总长,单位为s
+        #插入并折半排序        
+        insertsort(splittimestamp,split[4])   
+        
+        #nframes字节总长度/采样率
+        #print(nframes*1.0/8000); 输出329.537625等于5分29秒,如果相邻2段都小于17秒则结束
+        if timevalidate(splittimestamp,nframes*1.0/framerate,17):
             break
         splittimestamp.pop()
 
-    splittimestamp=sorted(splittimestamp)
-    print splittimestamp
+    #splittimestamp=sorted(splittimestamp)
+    #print splittimestamp
     basename=os.path.basename(wavepath)
     filename=os.path.splitext(basename)[0]
     savefilefolder=os.path.join(r'./temp',filename)
-    print 'save floder:',savefilefolder
+    #print 'save floder:',savefilefolder
     if os.path.exists(savefilefolder):
         shutil.rmtree(savefilefolder)      
    
@@ -87,48 +138,53 @@ if __name__ =="__main__":
     srtid=1
     maxrecognize=50
     lentimestamp=len(splittimestamp)
+    
+
     for i in range(len(splittimestamp)-1):
-        if i>maxrecognize:
-            print 'end recognize ',maxrecognize
-            break
+        #if i>maxrecognize:
+            #print 'end recognize ',maxrecognize
+            #break
         starttime=splittimestamp[i]
         endtime=splittimestamp[i+1]
         if endtime>nframes*1.0 / framerate:
-            print 'out of time',endtime,nframes*1.0 / framerate
+            #print 'out of time',endtime,nframes*1.0 / framerate
             endtime=nframes*1.0 / framerate
-        print starttime,endtime
+        #print starttime,endtime
         savefilename=str(i)+"_"+str(starttime)+"_"+str(endtime)
         savepath=os.path.join(savefilefolder,savefilename+'.wav')#overwrite
-        print 'savepath',savepath
-        try:
-            print 'export timerage:',starttime,endtime,' completion ',i,lentimestamp,i*1.0/lentimestamp
-            wav[starttime*1000:endtime*1000].export(savepath, format="wav") # 切e
-        except Exception as e:
-            print 'export exception',str(e)
-            continue
+        #print 'savepath',savepath
+        #try:
+            #print 'export timerage:',starttime,endtime,' completion ',i,lentimestamp,i*1.0/lentimestamp
+            #wav[starttime*1000:endtime*1000].export(savepath, format="wav") # 切e
+        #except Exception as e:
+            #print 'export exception',str(e)
+            #continue
         
         if framerate==8000 or framerate==16000:
-            response=speech_recognizai_baidu(savepath,framerate,laguage)            
+            #调用百度api
+            response=speech_recognizai_baidu(wav[starttime*1000:endtime*1000].raw_data,framerate,laguage)           
             savejsonpath=os.path.join(savefilefolder,savefilename+'.json') 
             #print str(response)
+            #解析百度的回复{'corpus_no': '6462566101916659365', 'result': ['he,', 'e,', 'here,', 'each,', 'a,'],
+            #'err_msg': 'success.', 'err_no': 0, 'sn': '949466616181504683425'}百度给出前5种可能的识别结果
             if response['err_no']==0:      
                 recognize_txt=(response['result'][0])
-                for r in recognize_txt:
-                    print r,
-                print ''
+                #for r in recognize_txt:
+                    #print(r)
+                #print ''
                 #write_txt_to_file(savejsonpath,recognize_txt.encode('utf-8'))
                 startstr=seconds_to_timestamp_str(starttime)
                 endstr=seconds_to_timestamp_str(endtime)
                 srtpath=os.path.join(savefilefolder,filename+'.srt')
                 asspath=os.path.join(savefilefolder,filename+'.ass ')
-                if srtid<10:
-                    recognize_txt=("%s     %s")%(u'subtitle(autocreated) wj3235@126.com =>',recognize_txt)                    
+                #if srtid<10:
+                    #recognize_txt=("%s     %s")%(u'subtitle(autocreated) wj3235@126.com =>',recognize_txt)                    
                     
-                srttxt=('%s\n%s-->%s\n%s\n\n')%(srtid,startstr,endstr,recognize_txt)
-                asstxt=('Dialogue:0,%s,%s,AGMStyle,NTP,0000,0000,0000,,%s\n')%(startstr,endstr,recognize_txt)
+                srttxt=('%s\n%s --> %s\n%s\n')%(srtid,startstr,endstr,recognize_txt)
+                #asstxt=('Dialogue:0,%s,%s,AGMStyle,NTP,0000,0000,0000,,%s\n')%(startstr,endstr,recognize_txt)
                 write_txt_to_file(srtpath,srttxt.encode('utf-8'))
                 #write_txt_to_file(asspath,asstxt.encode('utf-8'))
                 
                 srtid+=1
-                print 'save ok'
+                #print 'save ok'
                 

--- a/src/ffmpeg.md
+++ b/src/ffmpeg.md
@@ -1,0 +1,23 @@
+一,提取音频文件,从视频中
+	-ar 音频采样率
+	-ac 频道数
+	
+	ffmpeg -i AomawaShields_2015U.mp4 -ac 1 -ar 16000 -f wav -vn ted80001.wav
+	
+	提取效率分析
+	大概是10-15s/G的提取速度
+	1.6G->85M音频 91min
+	55M->5M音频 5min
+	200M->66M  72min
+	视频质量越高提取率越低 大概5%-30%左右 但是生成音频大小约为 50M/h
+	
+
+二,合成字幕 1-2min/h
+
+	嵌入外挂字幕 ffmpeg -i AomawaShields_2015U.mp4 -i ted80001.srt -c:s mov_text -c:v copy -c:a copy AomawaShields_2015U2.mp4	
+
+	合成带字幕视频ffmpeg -i AomawaShields_2015U.mp4 -vf subtitles=ted80001.srt AomawaShields_2015U2.mp4	
+	
+三,剪辑视频
+
+	ffmpeg  -i AomawaShields_2015U.mp4 -vcodec copy -acodec copy -ss 00:00:00 -to 00:04:30 4.flv -y

--- a/src/speechrecognize.py
+++ b/src/speechrecognize.py
@@ -26,5 +26,13 @@ def baidu(filePath,samplerate,language):
     return response
         
 def speech_recognizai_baidu(filepath,samplerate,language='zh'):
-    return baidu(filepath,samplerate,language)
+    return baidu2(filepath,samplerate,language)
     
+def baidu2(filestream,samplerate,language):
+    global APP_ID,API_KEY,SECRET_KEY
+    aipSpeech = AipSpeech(APP_ID, API_KEY, SECRET_KEY)
+        
+    response=aipSpeech.asr(filestream, 'wav', samplerate, {
+        'lan': language,
+    })
+    return response

--- a/src/utility.py
+++ b/src/utility.py
@@ -6,7 +6,7 @@ Created on Sun Aug 06 05:26:49 2017
 """
 
 def write_txt_to_file(path,txt):
-    with open(path,'a+') as f:
+    with open(path,'ab+') as f:
         f.write(txt)
 
 def seconds_to_timestamp_str(seconds):


### PR DESCRIPTION
1中值滤波scipy.signal.medfilt计算速度较慢,更新计算方法
2get_wave_statistic函数添加framerate(采样率)参数,支持8000/16000,添加处理(无声音时长超过17s切为多个16.999s的无声音时长)
3calculate_other_statistic_info函数添加framerate(采样率)参数,支持8000/16000
4修改原来循环排序生成间隔小于17s时间点数组算法(每次循环采用折半插入排序,因为插入的是排好序的数组,原来每次循环采用sort,视频时长超过1小时的话基本算不完了...)
5去掉原来将wav切成具体的小文件步骤,直接使用流访问百度api
6修改保存字幕格式可以直接使用ffmpeg将字幕烧制到视频中
7修改speech_recognizai_baidu方法接受流,不再去读文件
8添加了一些注释
9添加ffmpeg分离音频,烧制字幕指令